### PR TITLE
fix: command detection false positives in search, linter, and git techniques

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,29 @@ The plugin intercepts `tool_result` events and applies appropriate filtering bas
 
 Metrics are tracked in-memory and can be viewed with `/rtk-stats`.
 
+## Known issues
+
+### `isSearchCommand` / `isLinterCommand`: substring false positives
+
+`includes()` matches anywhere in the command string, not just at the command name position:
+
+| Check | False positive examples |
+|---|---|
+| `includes("ag")` | `npm run agent`, `manage.py`, any path containing "package" |
+| `includes("find")` | paths containing "find", `findall()` calls |
+| `includes("black")` | `blacklist`, any path with "black" in it |
+| `includes("ruff")` | any path containing "ruff" |
+
+When a false positive fires the command's output is silently replaced with a reformatted summary, discarding the real output the agent needed. `isTestCommand` had the same bug and was fixed in commit 2245040 — `isSearchCommand` and `isLinterCommand` need the same treatment.
+
+### `isGitCommand`: `startsWith` never matches in practice
+
+`startsWith("git status")` requires the command to begin with `git`. Agents routinely prefix with a directory change: `cd /repo && git status`. In practice this means gitCompaction is silently inert for compound commands.
+
+### `compactStatus`: corrupts verbose `git status` output
+
+`compactStatus` expects porcelain format (`git status -s` / `--short`). When called with plain `git status` output, the parser misreads English prose as two-char status codes — `"Changes not staged for commit:"` is read as `status[0] = 'C'` (staged), producing output like `"Staged: 1 files / nges not staged for commit:"` while real modified files go unreported.
+
 ## License
 
 MIT - Based on the RTK specification

--- a/techniques/git.ts
+++ b/techniques/git.ts
@@ -1,12 +1,23 @@
-const GIT_COMMANDS = ["git diff", "git status", "git log", "git show", "git stash"];
+const GIT_SUBCOMMANDS = ["diff", "status", "log", "show", "stash"];
+
+// Matches "git <sub>" at the start of a string OR after a shell chain operator
+// (&&, ||, ;, |). Handles both bare "git status" and "cd /path && git status".
+const GIT_COMMAND_RE = new RegExp(
+	`(?:^|&&\\s*|\\|\\|\\s*|;\\s*|\\|\\s*)git\\s+(${GIT_SUBCOMMANDS.join("|")})(?:\\s|$)`,
+	"m"
+);
 
 export function isGitCommand(command: string | undefined | null): boolean {
 	if (typeof command !== "string" || command.length === 0) {
 		return false;
 	}
+	return GIT_COMMAND_RE.test(command);
+}
 
-	const cmdLower = command.toLowerCase();
-	return GIT_COMMANDS.some((gc) => cmdLower.startsWith(gc));
+// Extract the first matching git subcommand from a (possibly compound) command.
+function getGitSubcommand(command: string): string | null {
+	const m = GIT_COMMAND_RE.exec(command);
+	return m ? m[1] : null;
 }
 
 export function compactDiff(output: string, maxLines: number = 50): string {
@@ -97,11 +108,27 @@ interface StatusStats {
 	untrackedFiles: string[];
 }
 
-export function compactStatus(output: string): string {
+export function compactStatus(output: string): string | null {
 	const lines = output.split("\n");
 
 	if (lines.length === 0 || (lines.length === 1 && lines[0].trim() === "")) {
 		return "Clean working tree";
+	}
+
+	// Guard: `git status` without -s/--short produces verbose prose output that
+	// this parser cannot handle — it expects porcelain format (two-char status
+	// codes, optional "##" branch header). Verbose output starts with English
+	// sentences; passing it through produces garbage like:
+	//   "Staged: 1 files / nges not staged for commit:"
+	// Return null to leave the output unchanged.
+	const firstNonEmpty = lines.find((l) => l.trim().length > 0) ?? "";
+	const looksVerbose =
+		firstNonEmpty.startsWith("On branch") ||
+		firstNonEmpty.startsWith("HEAD detached") ||
+		firstNonEmpty.startsWith("nothing to commit") ||
+		firstNonEmpty.startsWith("No commits yet");
+	if (looksVerbose) {
+		return null;
 	}
 
 	const stats: StatusStats = {
@@ -227,17 +254,18 @@ export function compactGitOutput(
 		return null;
 	}
 
-	const cmdLower = command.toLowerCase();
+	const sub = getGitSubcommand(command);
 
-	if (cmdLower.startsWith("git diff")) {
+	if (sub === "diff") {
 		return compactDiff(output);
 	}
 
-	if (cmdLower.startsWith("git status")) {
+	if (sub === "status") {
+		// compactStatus returns null for verbose output — pass through unchanged.
 		return compactStatus(output);
 	}
 
-	if (cmdLower.startsWith("git log")) {
+	if (sub === "log") {
 		return compactLog(output);
 	}
 

--- a/techniques/linter.ts
+++ b/techniques/linter.ts
@@ -24,7 +24,12 @@ export function isLinterCommand(command: string | undefined | null): boolean {
 	}
 
 	const cmdLower = command.toLowerCase();
-	return LINTER_COMMANDS.some((lc) => cmdLower.includes(lc));
+	return LINTER_COMMANDS.some((lc) => {
+		const escaped = lc.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		// Match the command name only at a command position, not as a substring.
+		// Prevents "black" matching "blacklist", "ruff" matching paths, etc.
+		return new RegExp(`(?:^|[|;&]\\s*)${escaped}(?:\\s|$|[|;&])`, "m").test(cmdLower);
+	});
 }
 
 function parseIssues(output: string, linterType: string): Issue[] {

--- a/techniques/search.ts
+++ b/techniques/search.ts
@@ -6,7 +6,13 @@ export function isSearchCommand(command: string | undefined | null): boolean {
 	}
 
 	const cmdLower = command.toLowerCase();
-	return SEARCH_COMMANDS.some((sc) => cmdLower.includes(sc));
+	return SEARCH_COMMANDS.some((sc) => {
+		const escaped = sc.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		// Match the command name only at a command position (start of string or
+		// after a shell operator), not as a substring of another word.
+		// Prevents "ag" matching "agent"/"package", "find" matching path components.
+		return new RegExp(`(?:^|[|;&]\\s*)${escaped}(?:\\s|$|[|;&])`, "m").test(cmdLower);
+	});
 }
 
 interface SearchResult {


### PR DESCRIPTION
## Summary

Three `is*Command` functions identify bash commands using `includes()` or `startsWith()`, causing two classes of bug: **false positives** that silently reformat unrelated output, and a **silent no-op** where a technique never fires at all.

---

## Bug 1 — `isSearchCommand` and `isLinterCommand`: substring false positives

`includes()` matches anywhere in the command string, not just at the command name position:

| Check | False positive |
|---|---|
| `includes("ag")` | `npm run agent`, `manage.py`, any path with "package" |
| `includes("find")` | paths containing "find", Python `findall()` calls |
| `includes("black")` | `blacklist`, `black_scholes`, any path with "black" |
| `includes("ruff")` | any path containing "ruff" |

When a false positive fires, the command's output is silently parsed as search/linter results and replaced with a reformatted summary — discarding the real output the agent needed.

**Note:** `isTestCommand` had the same bug and was fixed in commit 2245040 with word-boundary regex. This PR applies the same fix to `isSearchCommand` and `isLinterCommand`.

## Bug 2 — `isGitCommand`: `startsWith` never matches in practice

Agents routinely prefix git commands with a directory change:

```bash
cd /home/user/project && git status
cd /home/user/project && git log --oneline -5
```

`startsWith("git status")` requires the string to begin with `git`, so these never match. Across a sample of 908 git commands in agent session logs, **0 matched** the old `startsWith` pattern. `gitCompaction` was silently inert for all of them.

## Bug 3 — `compactStatus`: corrupts verbose `git status` output

`compactStatus` expects porcelain format (`git status -s` / `--short`). When called with verbose output (`git status` without flags), the parser misreads English prose as two-char status codes:

```
Input line: "Changes not staged for commit:"
status[0] = 'C'  → 'C' is in ["M","A","D","R","C"] → staged++
filename   = "anges not staged for commit:"
```

Result shown to the agent:
```
Staged: 1 files
  nges not staged for commit:
```

Real modified files are not shown; a garbage filename is. Fixed by detecting verbose output on the first non-empty line and returning `null` (pass-through) instead.

---

## Changes

- **`techniques/search.ts`** — `isSearchCommand`: regex word-boundary match instead of `includes()`
- **`techniques/linter.ts`** — `isLinterCommand`: same fix
- **`techniques/git.ts`**:
  - `isGitCommand`: regex matching `git <sub>` after `&&`, `||`, `;`, `|` as well as at start of string
  - `compactStatus`: return `null` for verbose prose output; caller passes through unchanged
  - `compactGitOutput`: use `getGitSubcommand()` helper; handle `null` from `compactStatus`